### PR TITLE
Add pytest test for schoolyard retorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Erics_Chatbot
+
+This project contains a small Flask application that serves a retro style chatbot.
+
+## Running Tests
+
+Tests are written using [pytest](https://pytest.org). To execute the test suite, run:
+
+```bash
+pytest
+```
+
+This will automatically discover and run tests such as `test_retorts.py`.

--- a/test_retorts.py
+++ b/test_retorts.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import pytest
+
+# Stub modules used by app that may not be installed in the test environment
+sys.modules.setdefault('oci', types.ModuleType('oci'))
+
+flask_stub = types.ModuleType('flask')
+class FakeFlask:
+    def __init__(self, *args, **kwargs):
+        pass
+    def route(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+flask_stub.Flask = FakeFlask
+flask_stub.render_template = lambda *a, **k: ""
+flask_stub.request = object()
+flask_stub.jsonify = lambda *a, **k: {}
+sys.modules.setdefault('flask', flask_stub)
+
+from app import get_schoolyard_retort
+
+# Predefined retorts list from app.py
+RETORTS = [
+    "I know you are, but what am I?",
+    "Your mom!",
+    "No backsies!",
+    "Takes one to know one!",
+    "I'm rubber, you're glue, whatever you say bounces off me and sticks to you!",
+    "Last one there is a rotten egg!",
+    "Not uh!",
+    "Yeah, well, double infinity no take-backs!",
+    "Make me!",
+    "Oh yeah? Prove it!",
+    "Psych!",
+    "Liar, liar, pants on fire!",
+    "You and what army?",
+    "Did too! Did not! Did too! Did not!",
+    "Betcha can't catch me!",
+]
+
+def test_get_schoolyard_retort_multiple_calls():
+    # Call the function multiple times to ensure randomness doesn't matter
+    for _ in range(20):
+        retort = get_schoolyard_retort()
+        assert retort in RETORTS


### PR DESCRIPTION
## Summary
- add regression test for `get_schoolyard_retort`
- document running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7764341883338872259ab2bf2816